### PR TITLE
Makefile: fix cpu detection on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # MaSurCA version
 NAME=MaSuRCA
 VERSION = 3.3.1
-NCPU = $(shell grep -c '^processor' /proc/cpuinfo 2>/dev/null || sysctl hw.ncpu 2>/dev/null || echo 1)
+NCPU = $(shell grep -c '^processor' /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
 
 # Component versions
 COMPONENTS = global


### PR DESCRIPTION
The `NCPU` environment variable is incorrectly set on macOS. This pull request fixes the issue.

Though adding `MAKEFLAGS+="j"` at the beginning would have the same effect without running system-specific commands.

(I also think that the user themselves should be specifying the number of parallel jobs in the `make` invocation, but this is a personal difference of opinion.)

```console
$ sysctl hw.ncpu
hw.ncpu: 4
```

```console
$ sysctl -n hw.ncpu
4
```